### PR TITLE
Reset riak_pb dependency to a release tag.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
 {erl_opts, [debug_info]}.
 {deps, [
-        {riak_pb, "1.3.3", {git, "git://github.com/basho/riak_pb.git", {tag, "1.3.3"}}}
+        {riak_pb, "1.3.0", {git, "git://github.com/basho/riak_pb.git", {tag, "1.3.0"}}}
        ]}.


### PR DESCRIPTION
This is the beginning of an attempt to untangle some broken and twisted dependency changes.
