### PR TITLE
bumped riak_pb to 1.4.0.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
 {erl_opts, [debug_info]}.
 {deps, [
-        {riak_pb, "1.4.0.2", {git, "git://github.com/basho/riak_pb.git", {tag, "1.4.0.2"}}}
+        {riak_pb, "1.4.0.3", {git, "git://github.com/basho/riak_pb.git", {tag, "1.4.0.3"}}}
        ]}.


### PR DESCRIPTION
get-deps on riak_ee fails without this patch
