### PR TITLE
Switch back to develop branch.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
 {erl_opts, [debug_info]}.
 {deps, [
-        {riak_pb, "2.0.0.4", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.4"}}}
+        {riak_pb, "2.0.0.7", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.7"}}}
        ]}.


### PR DESCRIPTION
`riak_repl` `develop` branch fails to build now because of a version mismatch.  Not sure if this is right, but I figured for now `develop` should be targeting `develop` on `riak_pb`.  The version mismatch is asking for 2.0.0.4 on a branch providing 2.0.0.7. @jaredmorrow 
