### PR TITLE
Update riak_pb to 2.1.0.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
 {erl_opts, [debug_info, warnings_as_errors]}.
 {deps, [
-        {riak_pb, "2.1.0.1", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.1"}}}
+        {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.2"}}}
        ]}.


### PR DESCRIPTION
To align version with riak-erlang-client ( to include https://github.com/basho/riak_pb/pull/113 , https://github.com/basho/riak-erlang-client/pull/210 )
